### PR TITLE
Corrected the _USE_SYSTEM_TIME_ flag and added a confirmation printout

### DIFF
--- a/Source/42init.c
+++ b/Source/42init.c
@@ -3996,9 +3996,10 @@ void InitSim(int argc, char **argv)
             &Matl,&Nmatl,Geom,&Ngeom,&JunkTag,FALSE);
 
 /* .. Time */
-      #if defined _USE_SYTEM_TIME_
+      #if defined _USE_SYSTEM_TIME_
          if (TimeMode == EXTERNAL_TIME) {
-            RealSystemTime(&Year,&doy,&Month,&Day,&Hour,&Minute,&Second);
+            printf("Initializing with external time\n");
+            RealSystemTime(&Year,&doy,&Month,&Day,&Hour,&Minute,&Second,DTSIM);
          }
       #endif
       AbsTime0 = DateToAbsTime(Year,Month,Day,Hour,Minute,Second);


### PR DESCRIPTION
Addresses Issue #31 , which was caused by a missing capital `S` in an `#if defined` macro. I also added the missing argument o the `RealSystemTime` call in this block, and added a printout to inform the user that EXTERNAL timemode is in use. 

With this patch, simulations using the EXTERNAL timemode initialize correctly in time, position, and (if used) local-frame attitude.