### PR TITLE
Added time conversion from UTC to TT in EXTERNAL mode initialization

### DIFF
--- a/Source/42init.c
+++ b/Source/42init.c
@@ -4000,18 +4000,14 @@ void InitSim(int argc, char **argv)
          if (TimeMode == EXTERNAL_TIME) {
             printf("Initializing with external time\n");
             RealSystemTime(&Year,&doy,&Month,&Day,&Hour,&Minute,&Second,DTSIM);
-
-            /* Assume External Time is UTC.  Convert to TT for AbsTime */
-            AtomicTime = DateToAbsTime(Year,Month,Day,Hour,Minute,Second+LeapSec);
-            AbsTime = AtomicTime + 32.184;
-            AbsTimeToDate(AbsTime,&Year,&Month,&Day,&Hour,&Minute,&Second,DTSIM);
          }
       #endif
-      AbsTime0 = DateToAbsTime(Year,Month,Day,Hour,Minute,Second);
+
+      AtomicTime = DateToAbsTime(Year,Month,Day,Hour,Minute,Second+LeapSec);
       doy = MD2DOY(Year,Month,Day);
-      JulDay = AbsTimeToJD(AbsTime0);
-      AbsTime = AbsTime0;
-      AtomicTime = AbsTime - 32.184; /* TAI */
+      AbsTime = AtomicTime + 32.184;
+      JulDay = AbsTimeToJD(AbsTime);
+      AbsTime0 = AbsTime;
       CivilTime = AtomicTime - LeapSec; /* UTC "clock" time */
       GpsTime = AtomicTime - 19.0;
       JDToGpsTime(JulDay,&GpsRollover,&GpsWeek,&GpsSecond);

--- a/Source/42init.c
+++ b/Source/42init.c
@@ -4000,6 +4000,11 @@ void InitSim(int argc, char **argv)
          if (TimeMode == EXTERNAL_TIME) {
             printf("Initializing with external time\n");
             RealSystemTime(&Year,&doy,&Month,&Day,&Hour,&Minute,&Second,DTSIM);
+
+            /* Assume External Time is UTC.  Convert to TT for AbsTime */
+            AtomicTime = DateToAbsTime(Year,Month,Day,Hour,Minute,Second+LeapSec);
+            AbsTime = AtomicTime + 32.184;
+            AbsTimeToDate(AbsTime,&Year,&Month,&Day,&Hour,&Minute,&Second,DTSIM);
          }
       #endif
       AbsTime0 = DateToAbsTime(Year,Month,Day,Hour,Minute,Second);


### PR DESCRIPTION
Integrates the time initialization fix proposed by @ericstoneking in Issue #33. This patch removes the ~32 second gap between the first and second time steps of simulations running in EXTERNAL timemode.