### PR TITLE
Propagate orbits to current time after initialization

### DIFF
--- a/Source/42init.c
+++ b/Source/42init.c
@@ -4112,7 +4112,8 @@ void InitSim(int argc, char **argv)
       for(Iorb=0;Iorb<Norb;Iorb++) {
          if (Orb[Iorb].Exists) InitOrbit(&Orb[Iorb]);
       }
-
+      // propagate orbits to current time
+      OrbitMotion();
       LoadTdrs();
       
       RNG = CreateRandomProcess(1);


### PR DESCRIPTION
Just adding a call to OrbitMotion() at the end of InitSim(). This fixes an issue where in the first time step of logging, all orbit locations are in their respective epoch locations, while in the second time step, they have been propagated to the current simulation time. This fix ensures that orbits are propagated the simulation time at the end of initialization.