### PR TITLE
Added SetOrbitLocalFrames() for correct Local Frame attitude initialization

### DIFF
--- a/Include/42.h
+++ b/Include/42.h
@@ -161,6 +161,7 @@ EXTERN struct ConstellationType Constell[89];
 
 long SimStep(void);
 void Ephemerides(void);
+void SetOrbitLocalFrames(void);
 void OrbitMotion(void);
 void Environment(struct SCType *S);
 void Perturbations(struct SCType *S);

--- a/Source/42init.c
+++ b/Source/42init.c
@@ -4130,6 +4130,7 @@ void InitSim(int argc, char **argv)
          if (Orb[Iorb].Exists) InitOrbit(&Orb[Iorb]);
       }
       OrbitMotion();
+      SetOrbitLocalFrames();
       for (Isc=0;Isc<Nsc;Isc++) {
          if (SC[Isc].Exists) {
             InitSpacecraft(&SC[Isc]);


### PR DESCRIPTION
This PR extracts a section of code from `Ephemerides()` and exposes it as a separate function so that it can be called after `OrbitMotion` but before `InitSpacecraft`. Making this change allows **L**ocal frame attitudes to be set correctly.

Here are the first few lines of the `RPY.42` files from the same sim, run on the current `master` branch and on this PR's branch:
**Master:**
```
$ cat IO3/RPY.42
145.888051 -6.967286 -91.701655
146.377429 -7.657798 -90.696447
146.891195 -8.299216 -89.662369
147.426271 -8.922347 -88.620715
...
```
**PR:**
```
$ cat IO3/RPY.42
60.000000 50.000000 40.000000
60.305622 50.821270 40.707388
60.539364 51.626788 41.487923
60.738877 52.434942 42.292174
...
```
These sims were run with the following attitude initialization in a file called `SC_Simple.txt`:
```
*************************** Initial Attitude ***************************
NAL                           ! Ang Vel wrt [NL], Att [QA] wrt [NLF]
0.6    0.5    1.0             ! Ang Vel (deg/sec)
0.0    0.0    0.0    1.0      ! Quaternion
60.0  50.0   40.0    123      ! Angles (deg) & Euler Sequence
```

The code in this PR produces the correct initial LVLH attitude, allowing the user to conveniently set LVLH attitudes if desired.