### PR TITLE
Removed last reference to _USE_SYSTEM_TIME_, runtime printout now works better

### DIFF
--- a/Source/42exec.c
+++ b/Source/42exec.c
@@ -316,10 +316,10 @@ long SimStep(void)
       if (First) {
          First = 0;
          SimTime = 0.0;
-         #if defined _USE_SYSTEM_TIME_
-            /* First call just initializes timer */
-            RealRunTime(&TotalRunTime,DTSIM);
-         #endif
+
+         /* First call just initializes timer */
+         RealRunTime(&TotalRunTime,DTSIM);
+
          ManageFlags();
 
          Ephemerides(); /* Sun, Moon, Planets, Spacecraft, Useful Auxiliary Frames */


### PR DESCRIPTION
After one of the recent commits, I noticed that the Sim Speed printout that shows up at the end of the FAST mode sim wasn't working correctly. Instead of a finite runtime, I saw a result like this:

```
    42 Case ./IO3// is  90% Complete at Time =     4500.000
    42 Case ./IO3// is 100% Complete at Time =     5000.000
     Total Run Time =      0.00 sec
     Sim Speed =      inf x Real
```

This PR fixes that problem by removing an `#if defined` block that refers to the _USE_SYSTEM_TIME_ flag, which is now no longer used. With this patch in place, sim runtimes look much more reasonable:

```
   42 Case ./IO3// is  90% Complete at Time =     4500.000
    42 Case ./IO3// is 100% Complete at Time =     5000.000
     Total Run Time =      2.40 sec
     Sim Speed =  2083.33 x Real
```

I also looked through the codebase and I think this is the last place where the _USE_SYSTEM_TIME_ flag is used, so there shouldn't be any other bugs related to this flag.

