### PR TITLE
Added code fixes to J2/TLE errors

### DIFF
--- a/Kit/Include/orbkit.h
+++ b/Kit/Include/orbkit.h
@@ -196,7 +196,8 @@ void  RV2Eph(double time, double mu, double xr[3], double xv[3],
 void TLE2Eph(const char Line1[80], const char Line2[80], double JD,
    double mu, double *SMA, double *e, double *i, double *RAAN,
    double *ArgP, double *th, double *tp, double *SLR,
-   double *alpha, double *rmin, double *Period, double *MeanMotion);
+   double *alpha, double *rmin, double *Period, double *MeanMotion,
+   double *TLEEpoch);
 long LoadTleFromFile(const char *Path, const char *TleFileName, const char *TleLabel,
                       double JD, double mu, struct OrbitType *O);
 double RV2RVp(double mu, double r[3], double v[3], double rp[3], double vp[3]);

--- a/Kit/Source/orbkit.c
+++ b/Kit/Source/orbkit.c
@@ -400,7 +400,8 @@ void  RV2Eph(double time, double mu, double xr[3], double xv[3],
 void TLE2Eph(const char Line1[80], const char Line2[80], double JD,
    double mu, double *SMA, double *e, double *i, double *RAAN,
    double *ArgP, double *th, double *tp, double *SLR,
-   double *alpha, double *rmin, double *Period, double *MeanMotion)
+   double *alpha, double *rmin, double *Period, double *MeanMotion,
+   double *TLEEpoch)
 {
 #define TWOPI (6.283185307179586)
 #define D2R (1.74532925199E-2)
@@ -432,6 +433,10 @@ void TLE2Eph(const char Line1[80], const char Line2[80], double JD,
       JDepoch += FracDay;
       Epoch = JDToTime(JDepoch);
       DynTime = JDToTime(JD);
+
+      // sets Orbit Epoch to the TLE epoch. useful for
+      // correcting J2 drift at startup
+      *TLEEpoch = Epoch;
 
       strncpy(IncString,&Line2[8],8);
       IncString[8] = 0;
@@ -501,7 +506,7 @@ long LoadTleFromFile(const char *Path, const char *TleFileName,
             TLE2Eph(line1,line2,JD,O->mu,
                &O->SMA,&O->ecc,&O->inc,&O->RAAN,&O->ArgP,&O->anom,
                &O->tp,&O->SLR,&O->alpha,&O->rmin,
-               &O->Period,&O->MeanMotion);
+               &O->Period,&O->MeanMotion, &O->Epoch);
             Eph2RV(O->mu,O->SLR,O->ecc,O->inc,O->RAAN,O->ArgP,
                    -O->tp,O->PosN,O->VelN,&O->anom);
          }

--- a/Source/42init.c
+++ b/Source/42init.c
@@ -641,6 +641,23 @@ void InitOrbit(struct OrbitType *O)
                      ElementLabel,ElementFileName);
                   exit(1);
                }
+               if (O->J2DriftEnabled) {
+                  O->RAAN0 = O->RAAN;
+                  O->ArgP0 = O->ArgP;
+                  printf("Arg:  %.3lf*\n",O->ArgP0*57.2958);
+                  printf("RAAN: %.3lf*\n",O->RAAN0*57.2958);
+
+                  FindJ2DriftParms(O->mu,World[O->World].J2,World[O->World].rad,O);
+
+                  O->RAAN0 = O->RAAN + O->RAANdot*(DynTime-O->Epoch);
+                  O->ArgP0 = O->ArgP + O->ArgPdot*(DynTime-O->Epoch);
+                  printf("Arg:  %.3lf deg\n",O->ArgP0*57.2958);
+                  printf("RAAN: %.3lf deg\n",O->RAAN0*57.2958);
+                  //O->tp = O->Epoch - TimeSincePeriapsis(O->MuPlusJ2,O->SLR,O->ecc,O->anom);
+                  //Eph2RV(O->MuPlusJ2,O->SLR,O->ecc,O->inc,
+                  //       O->RAAN,O->ArgP,O->Epoch-O->tp,
+                  //       O->PosN,O->VelN,&O->anom);
+               }
             }
             else if (ElementType == INP_TRV) {
                Success = LoadTRVfromFile(InOutPath, ElementFileName,


### PR DESCRIPTION
These patches fix Issue #43 , though I would welcome input on whether I used the `FindJ2DriftParms` appropriately. I confirmed this patch fixes the problem to my satisfaction by running an EXTERNAL time simulation using a TLE about two weeks out of date and finding that the SC location predicted by 42 was a very close match to the current TLE position predicted by N2YO.com for the same satellite. 