### PR TITLE
Implemented excessive memory usage fix

### DIFF
--- a/Source/42perturb.c
+++ b/Source/42perturb.c
@@ -141,7 +141,7 @@ void FindUnshadedAreas(struct SCType *S, double DirVecN[3])
       /* Put list of edges in sequence */
       for(Ie=0;Ie<SilNe-1;Ie++) {
          for(Je=Ie+1;Je<SilNe;Je++) {
-            if (SilEdge[Je].Body == SilEdge[Ie].Body 
+            if (SilEdge[Je].Body == SilEdge[Ie].Body
              && SilEdge[Je].Iv1 == SilEdge[Ie].Iv2) {
                memcpy(&SwapEdge,&SilEdge[Je],sizeof(struct SilEdgeType));
                memcpy(&SilEdge[Je],&SilEdge[Ie+1],sizeof(struct SilEdgeType));
@@ -242,8 +242,7 @@ void FindUnshadedAreas(struct SCType *S, double DirVecN[3])
                            }
                         }
                      }
-                     free(InVtx);
-                     InVtx = (struct SilVtxType *) calloc(SilNc,sizeof(struct SilVtxType));
+                     InVtx = (struct SilVtxType *) realloc(InVtx, SilNc*sizeof(struct SilVtxType));
                      memcpy(InVtx,ClipVtx,SilNc*sizeof(struct SilVtxType));
                      SilNin = SilNc;
                   }
@@ -318,7 +317,7 @@ void GravGradFrcTrq(struct SCType *S)
       double GravGradN[3][3],CGG[3][3],GravGradB[3][3],GGxI[3],GGxpn[3];
 
       O = &Orb[S->RefOrb];
-      
+
       if ((O->Regime == ORB_ZERO || O->Regime == ORB_FLIGHT) &&
            O->PolyhedronGravityEnabled) {
          W = &World[O->World];
@@ -349,7 +348,7 @@ void GravGradFrcTrq(struct SCType *S)
                }
             }
          }
-         
+
       }
       else {
          r = CopyUnitV(S->PosN,rhat);
@@ -399,9 +398,9 @@ void J2Force(struct SCType *S, struct OrbitType *O, double FrcN[3])
 {
       double Fh;
       long i;
-      
+
       Fh = S->mass*O->J2Fh1*sin(O->ArgP+O->anom);
-      
+
       for(i=0;i<3;i++) FrcN[i] = -Fh*S->CLN[1][i];
 }
 /**********************************************************************/


### PR DESCRIPTION
## Problem: 
42 accumulates something like 6 GB memory over an 8,000,000 second (1333.00 second wall time) simulation.

## Observations

I used valgrind to look for memory leaks: `$ valgrind --leak-check=full ./42 Pizza/`. This was easy because it turns out 42's Makefile uses the gcc flags to make debugging easy (`-g -O0`).

```
...
==140978== HEAP SUMMARY:
==140978==     in use at exit: 2,484,864 bytes in 952,184 blocks
==140978==   total heap usage: 5,070,861 allocs, 4,118,677 frees, 2,548,306,748 bytes allocated
==140978== 
==140978== 0 bytes in 5 blocks are definitely lost in loss record 30 of 172
==140978==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==140978==    by 0x16232D: FindUnshadedAreas (42perturb.c:246)
==140978==    by 0x163EF7: AeroFrcTrq (42perturb.c:513)
==140978==    by 0x16741E: Perturbations (42perturb.c:1084)
==140978==    by 0x10E28A: SimStep (42exec.c:332)
==140978==    by 0x10E53B: exec (42exec.c:409)
==140978==    by 0x10CED8: main (42main.c:41)
==140978== 
==140978== 0 bytes in 930,003 blocks are definitely lost in loss record 31 of 172
==140978==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==140978==    by 0x16232D: FindUnshadedAreas (42perturb.c:246)
==140978==    by 0x163EF7: AeroFrcTrq (42perturb.c:513)
==140978==    by 0x16741E: Perturbations (42perturb.c:1084)
==140978==    by 0x10E3A1: SimStep (42exec.c:365)
==140978==    by 0x10E53B: exec (42exec.c:409)
==140978==    by 0x10CED8: main (42main.c:41)
==140978== 
==140978== LEAK SUMMARY:
==140978==    definitely lost: 0 bytes in 930,008 blocks
==140978==    indirectly lost: 0 bytes in 0 blocks
==140978==      possibly lost: 0 bytes in 0 blocks
==140978==    still reachable: 2,484,864 bytes in 22,176 blocks
==140978==         suppressed: 0 bytes in 0 blocks
==140978== Reachable blocks (those to which a pointer was found) are not shown.
==140978== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==140978== 
==140978== For lists of detected and suppressed errors, rerun with: -s
==140978== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

Disabling Aero Forces and Torques in Inp_Sim.txt stops the issue - memory usage stays fixed at 3.2 MB for the full duration.

## Solution

Based on the valgrind results, it seems like the `calloc` call on line 246 of `42perturb.c` is the source of this memory usage issue.

Replacing that `calloc` call with the `realloc` pattern used in the surrounding code (the change in this PR) seems to stop the increasing memory usage and resolves the `valgrind` issues. Here is the valgrind output after the fix:

```
...
==141261== 
==141261== HEAP SUMMARY:
==141261==     in use at exit: 2,484,864 bytes in 22,174 blocks
==141261==   total heap usage: 3,954,849 allocs, 3,932,675 frees, 2,548,306,748 bytes allocated
==141261== 
==141261== LEAK SUMMARY:
==141261==    definitely lost: 0 bytes in 0 blocks
==141261==    indirectly lost: 0 bytes in 0 blocks
==141261==      possibly lost: 0 bytes in 0 blocks
==141261==    still reachable: 2,484,864 bytes in 22,174 blocks
==141261==         suppressed: 0 bytes in 0 blocks
==141261== Reachable blocks (those to which a pointer was found) are not shown.
==141261== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==141261== 
==141261== For lists of detected and suppressed errors, rerun with: -s
==141261== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Running 42 with this fix in place and with "Aerodynamic Forces & Torques (Shadows)" set to "TRUE TRUE", memory usage for my simulation stays at 3.2 MB for the entire duration of the simulation - much better than gaining 10s of MB of memory usage per wall-time second in FAST mode!