### PR TITLE
Add GitHub Actions build tests

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,35 @@
+name: C/C++ CI
+
+# run only on pushes or pull requests to master
+# this way you can develop on and push to separate branches without
+# using up runner minutes
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-ubuntu:
+    # default Ubuntu build
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make
+      
+  build-ubuntu-glut:
+    # Ubuntu build with GLUT graphics
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make GLUT_OR_GLFW=_USE_GLUT_
+      
+  build-ubuntu-no-graphics:
+    # Ubuntu build with all graphics disabled
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make GUIFLAG=


### PR DESCRIPTION
This PR adds the file ` .github/workflows/c-cpp.yml` that defines and enables a set of GitHub actions to be run whenever a commit is pushed to the master branch or when a pull request is opened against the master branch. The tests right now just compile 42 on an Ubuntu platform with a few different graphics options. More platforms and tests can be added down the line to run checks on Windows and MacOS. More discussion is in Issue https://github.com/ericstoneking/42/issues/70

Build minutes are limited to 2000 per month on free projects, after which Actions won't be run for the remainder of the month. So far these builds take about 6 minutes to run, so we could run the actions ~300 times per month before running out of minutes.