### PR TITLE
Fix J2 Earth Gravitational Parameter

### DIFF
--- a/Kit/Source/orbkit.c
+++ b/Kit/Source/orbkit.c
@@ -2560,7 +2560,7 @@ void FindJ2DriftParms(double mu, double J2, double Rw, struct OrbitType *O)
       O->J2Fh1 = -2.0*Coef*mu/p2*cos(O->inc)*sin(O->inc);
 
 /* .. Effective Mu */
-      O->MuPlusJ2 = O->mu - O->SMA*O->SMA*O->J2Fr0;
+      O->MuPlusJ2 = O->mu;
 
 /* .. Adjust mean motion, period */
       O->MeanMotion = sqrt(O->MuPlusJ2/O->SMA/O->SMA/O->SMA);


### PR DESCRIPTION
For a long time I've experienced an odd drift in 42 orbits relative to standard SGP4 orbit propagators. A lot of the time, this manifests as a difference in position between the a satellite in 42 initialized with a TLE and a the position an external TLE propagator says the satellite should be in at a certain time. The drift is on the order of 200 km per day with the J2 perturbation enabled and and 400 km per day with J2 disabled (mostly in the in-track direction). I thought this might just be due do solver differences or numerical error accumulation, but I recently found a fix.

On a whim, I decided to remove the strange change to the Earth's gravitational parameter Mu_earth that 42 makes when J2 drift is enabled:
```
thatch@bend:~/Desktop/Projects/42$ git diff
diff --git a/Kit/Source/orbkit.c b/Kit/Source/orbkit.c
index 6341c1a..1befe63 100644
--- a/Kit/Source/orbkit.c
+++ b/Kit/Source/orbkit.c
@@ -2560,7 +2560,7 @@ void FindJ2DriftParms(double mu, double J2, double Rw, struct OrbitType *O)
       O->J2Fh1 = -2.0*Coef*mu/p2*cos(O->inc)*sin(O->inc);
 
 /* .. Effective Mu */
-      O->MuPlusJ2 = O->mu - O->SMA*O->SMA*O->J2Fr0;
+      O->MuPlusJ2 = O->mu - 0*O->SMA*O->SMA*O->J2Fr0;
 
 /* .. Adjust mean motion, period */
       O->MeanMotion = sqrt(O->MuPlusJ2/O->SMA/O->SMA/O->SMA);
thatch@bend:~/Desktop/Projects/42$ 
```
This change keeps in place the terms for the J2 drift in right ascension of the ascending node (`O->RAANdot`) and argument of periapsis (`O->ArgPdot`), which are the main effects of the J2 perturbation. 

With the change in place, I rebuilt and reran the sim the J2 drift re-enabled and found that the drift between 42 and my other TLE propagator (`sgp4` from the Julia [SatelliteToolbox.jl](https://github.com/JuliaSpace/SatelliteToolbox.jl) package) is only 3-10 km per day! Way better! This is a huge usability improvement for my purposes.

I think the change to Mu might be there to account for drift of the argument of periapsis, which can kind of manifest as a change in the period of an orbit (as described by [this page](https://help.agi.com/stk/11.0.1/Content/stk/vehSat_orbitProp_2bodyJ2J4.htm) from AGI). Perhaps Mu was modified in order to emulate that change of orbital period effect, but causes problems elsewhere in the 42 propagator.

---

This small patch has made 42 much more accurate for my use case (single satellite around earth in low SSO). I hope this `MuPlusJ2` term as written in the original isn't required for anything else - I don't have a great way to check that this change doesn't negatively affect other propagation modes, but it absolutely helps for what I'm doing. Hopefully it's a good fix!