### PR TITLE
fix linux glfw

### DIFF
--- a/Docs/42 Flowchart.txt
+++ b/Docs/42 Flowchart.txt
@@ -16,7 +16,7 @@ exec
    InitSpacecraft
    InitFSW
    CmdInterpreter
-   HandoffToGui
+   HandoffToGuiGlut
       ReadGraphicsInputFile
       InitColors
       SetPovOrientation

--- a/Source/42exec.c
+++ b/Source/42exec.c
@@ -24,9 +24,9 @@
 
 #ifdef _ENABLE_GUI_
    #ifdef _USE_GLUT_
-      extern int HandoffToGui(int argc, char **argv);
+      extern int HandoffToGuiGlut(int argc, char **argv);
    #else
-      extern int HandoffToGui(void);
+      extern int HandoffToGuiGlfw(int argc, char **argv);
    #endif
 #endif
 
@@ -403,9 +403,9 @@ int exec(int argc,char **argv)
       #ifdef _ENABLE_GUI_
          if (GLEnable) {
             #ifdef _USE_GLUT_
-               HandoffToGui(argc,argv);
+               HandoffToGuiGlut(argc,argv);
             #else
-               HandoffToGui();
+               HandoffToGuiGlfw(argc,argv);
             #endif
          }
          else {

--- a/Source/42glfw.c
+++ b/Source/42glfw.c
@@ -1342,7 +1342,7 @@ long GuiCmdInterpreter(char CmdLine[512], double *CmdTime)
       return(NewCmdProcessed);
 }
 /*********************************************************************/
-void HandoffToGui(void)
+void HandoffToGuiGlfw(int argc, char ** argv)
 {
       PausedByMouse = 0;
 
@@ -1353,6 +1353,7 @@ void HandoffToGui(void)
       UpdatePOV();
 
       printf("Initializing glfw\n");
+      glutInit(&argc,argv);
       glfwSetErrorCallback(GlfwErrorHandler);
       if (!glfwInit()) {
          printf("Error initializing glfw\n");

--- a/Source/42glut.c
+++ b/Source/42glut.c
@@ -1366,7 +1366,7 @@ long GuiCmdInterpreter(char CmdLine[512], double *CmdTime)
       return(NewCmdProcessed);
 }
 /*********************************************************************/
-int HandoffToGui(int argc, char **argv)
+int HandoffToGuiGlut(int argc, char **argv)
 {
       PausedByMouse = 0;
 


### PR DESCRIPTION
Fixes #78 

From description of #77 :

Basically the glfw codeflow still requires some glut symbols which in turn require `glutInit`. This could be the case where in a constructor a glut class/function is used. Things might break for the glut codeflow if we just start commenting/removing things out, so the proper solution will most likely be an #ifdef glut wrapped around those glut symbols. However the way the code is structured glut symbols are always included so not sure how many ifdefs would be needed.

I was able to resolve the issue by just calling `glutInit` in the glfw codepath, which shouldn't break things on other systems like Apple or MSVC since once again glut is always included. (I'm making that statement off of these lines: https://github.com/ericstoneking/42/blob/master/Kit/Include/glkit.h#L23-L55) This does mean that I had to add `argc, **argv` to `HandoffToGui()` for glfw and with the same definition as the glut one I had to create two versions of the method.