### PR TITLE
suppress unused variable and string overread warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ $(OBJ)AppWriteToSocket.o $(OBJ)AppReadFromSocket.o $(OBJ)AppWriteToFile.o
 #ANSIFLAGS = -Wstrict-prototypes -pedantic -ansi -Werror
 ANSIFLAGS =
 
-CFLAGS = -fpic -Wall -Wshadow -Wno-deprecated -g  $(ANSIFLAGS) $(GLINC) $(CINC) -I $(INC) -I $(KITINC) -I $(KITSRC) $(GMSECINC) -O0 $(ARCHFLAG) $(GUIFLAG) $(GUI_LIB) $(SHADERFLAG) $(CFDFLAG) $(FFTBFLAG) $(GSFCFLAG) $(GMSECFLAG) $(STANDALONEFLAG)
+CFLAGS = -fpic -Wall -Wshadow -Wno-deprecated -Wno-unused-variable -Wno-unused-but-set-variable -g  $(ANSIFLAGS) $(GLINC) $(CINC) -I $(INC) -I $(KITINC) -I $(KITSRC) $(GMSECINC) -O0 $(ARCHFLAG) $(GUIFLAG) $(GUI_LIB) $(SHADERFLAG) $(CFDFLAG) $(FFTBFLAG) $(GSFCFLAG) $(GMSECFLAG) $(STANDALONEFLAG)
 
 
 ##########################  Rules to link 42  #############################

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ $(OBJ)AppWriteToSocket.o $(OBJ)AppReadFromSocket.o $(OBJ)AppWriteToFile.o
 #ANSIFLAGS = -Wstrict-prototypes -pedantic -ansi -Werror
 ANSIFLAGS =
 
-CFLAGS = -fpic -Wall -Wshadow -Wno-deprecated -Wno-unused-variable -Wno-unused-but-set-variable -g  $(ANSIFLAGS) $(GLINC) $(CINC) -I $(INC) -I $(KITINC) -I $(KITSRC) $(GMSECINC) -O0 $(ARCHFLAG) $(GUIFLAG) $(GUI_LIB) $(SHADERFLAG) $(CFDFLAG) $(FFTBFLAG) $(GSFCFLAG) $(GMSECFLAG) $(STANDALONEFLAG)
+CFLAGS = -fpic -Wall -Wshadow -Wno-deprecated -Wno-unused-variable -Wno-unused-but-set-variable -Wno-stringop-overread -g  $(ANSIFLAGS) $(GLINC) $(CINC) -I $(INC) -I $(KITINC) -I $(KITSRC) $(GMSECINC) -O0 $(ARCHFLAG) $(GUIFLAG) $(GUI_LIB) $(SHADERFLAG) $(CFDFLAG) $(FFTBFLAG) $(GSFCFLAG) $(GMSECFLAG) $(STANDALONEFLAG)
 
 
 ##########################  Rules to link 42  #############################

--- a/Source/42dynamics.c
+++ b/Source/42dynamics.c
@@ -3046,7 +3046,7 @@ void ScatterStates(struct JointType *G)
       double Pwu[3],Pvu[3],Pdwu[3];
       double pni[3],vi[3],Cvi[3],wxPvu[3],ai[3],Cai[3];
       double wxri[3],wxro[3],Calfri[3],wxPwu[3];
-      double axri[2],axro[3],wxwxri[3];
+      double axri[3],axro[3],wxwxri[3];
       double wxwxro[3],Cwi[3];
       double Iw[3],Ialfr[3],wxH[3];
       long i,j;


### PR DESCRIPTION
Resolves #80

suppress stringop-overread
suppress unused-variable
suppress unused-but-set-variable
fix a stringop-overflow warning