### PR TITLE
Lengthened 'label' buffer to avoid warnings.

### DIFF
--- a/Source/42gl.c
+++ b/Source/42gl.c
@@ -3740,7 +3740,7 @@ void DrawUnitSphere(void)
 {
       double lat,lng;
       long i,j,Im;
-      char label[20];
+      char label[23];
       
       struct FssType *F;
       struct StarTrackerType *ST;


### PR DESCRIPTION
Bumped 'label' buffer size in 42gl.c to 23, to get rid of many GCC 12 warnings about possible overruns.