### PR TITLE
ISSUE-165: ensure that /startapp.sh compiles 42

### DIFF
--- a/containers/.bashrc.local
+++ b/containers/.bashrc.local
@@ -1,0 +1,5 @@
+parse_git_branch() {
+     git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
+}
+export PS1="\u@\h \[\e[32m\]\w \[\e[91m\]\$(parse_git_branch)\[\e[00m\]$ "
+complete -W "\`grep -oP '^[a-zA-Z0-9_.%\-]+:([^=]|$)' ?akefile | sed 's/[^a-zA-Z0-9_.%\-]*$//'\`" make

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -10,16 +10,20 @@ ARG GIT_BRANCH=master
 ARG VNC_PASSWORD=0123456789
 
 ################################################################################
-FROM ${IMAGE_URI}
+FROM ${IMAGE_URI} AS x-vnc
 ################################################################################
+ARG VNC_PASSWORD
+ENV VNC_PASSWORD=${VNC_PASSWORD}
 
+
+################################################################################
+FROM x-vnc AS fortytwo
+################################################################################
 ARG GIT_URL
 ARG GIT_BRANCH
-ARG VNC_PASSWORD
 
 ENV GIT_URL=${GIT_URL}
 ENV GIT_BRANCH=${GIT_BRANCH}
-ENV VNC_PASSWORD=${VNC_PASSWORD}
 
 # VNC Config
 RUN mkdir -p ~/.vnc/

--- a/containers/Dockerfile_with_build_x-vnc
+++ b/containers/Dockerfile_with_build_x-vnc
@@ -1,0 +1,121 @@
+ARG REGISTRY_HOST=docker.io
+ARG IMAGE_USERNAME=library
+ARG IMAGE_NAME=ubuntu
+ARG IMAGE_TAG=24.04
+# don't use 25.04 as of May 20, 2025, it breaks 'usleep'
+
+ARG IMAGE_URI=${REGISTRY_HOST}/${IMAGE_USERNAME}/${IMAGE_NAME}:${IMAGE_TAG}
+
+ARG GIT_URL=https://github.com/ericstoneking/42.git
+ARG GIT_BRANCH=master
+ARG VNC_PASSWORD=0123456789
+
+################################################################################
+FROM ${IMAGE_URI} AS x-vnc
+################################################################################
+ARG VNC_PASSWORD
+ENV VNC_PASSWORD=${VNC_PASSWORD}
+
+RUN apt-get update && \
+    apt-get install -y \
+      gnupg \
+      wget \
+      apt-transport-https \
+      software-properties-common \
+      novnc \
+      websockify \
+      libxv1 \
+      libglu1-mesa \
+      xauth \
+      x11-utils \
+      xterm \
+      xorg \
+      tightvncserver && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# turbovnc: https://turbovnc.org/
+RUN wget -q -O- https://packagecloud.io/dcommander/turbovnc/gpgkey |  gpg --dearmor >/etc/apt/trusted.gpg.d/TurboVNC.gpg
+RUN wget -P /etc/apt/sources.list.d/ https://raw.githubusercontent.com/TurboVNC/repo/main/TurboVNC.list
+
+# virtualgl: https://virtualgl.org/
+RUN wget -q -O- https://packagecloud.io/dcommander/virtualgl/gpgkey | gpg --dearmor >/etc/apt/trusted.gpg.d/VirtualGL.gpg
+RUN wget -P /etc/apt/sources.list.d/ https://raw.githubusercontent.com/VirtualGL/repo/main/VirtualGL.list
+
+# Install virtualgl and turbovnc
+RUN apt-get update && \
+    apt-get install -y \
+      virtualgl \
+      turbovnc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install and configure Display Manager(s) - https://fluxbox.org/
+RUN apt-get update && \
+    apt-get install -y \
+      fluxbox && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# TODO: need to figure out why this is needed
+RUN ln -sf /usr/share/xsessions/fluxbox.desktop /usr/share/xsessions/gnome.desktop
+
+# Install tools for git cloning and development, etc.
+RUN apt-get update && \
+    apt install -y curl git build-essential vim jq xq tree tmux htop bash-completion dos2unix netcat-traditional iputils-ping && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install https://taskfile.dev/ (Taskfile.yaml)
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
+
+# Install some useful .bashrc-isms
+COPY .bashrc.local /root/.bashrc.local
+RUN cat /root/.bashrc.local >> /root/.bashrc
+
+# VNC Config
+RUN mkdir -p ~/.vnc/
+RUN echo ${VNC_PASSWORD} | vncpasswd -f > ~/.vnc/passwd
+RUN chmod 0600 ~/.vnc/passwd
+RUN openssl req -x509 -nodes -newkey rsa:2048 -keyout ~/novnc.pem -out ~/novnc.pem -days 3650 -subj "/C=US/ST=NY/L=NY/O=NY/OU=NY/CN=NY emailAddress=email@example.com"
+
+
+################################################################################
+FROM x-vnc AS fortytwo
+################################################################################
+ARG GIT_URL
+ARG GIT_BRANCH
+
+ENV GIT_URL=${GIT_URL}
+ENV GIT_BRANCH=${GIT_BRANCH}
+
+# VNC Config
+RUN mkdir -p ~/.vnc/
+RUN echo ${VNC_PASSWORD} | vncpasswd -f > ~/.vnc/passwd
+RUN chmod 0600 ~/.vnc/passwd
+RUN openssl req -x509 -nodes -newkey rsa:2048 -keyout ~/novnc.pem -out ~/novnc.pem -days 3650 -subj "/C=US/ST=NY/L=NY/O=NY/OU=NY/CN=NY emailAddress=email@example.com"
+
+# Install 42's dependencies
+RUN apt-get update && \
+    apt-get -y install libglu1-mesa-dev freeglut3-dev mesa-common-dev libglfw3-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# 42's MonteCarlo dependencies
+RUN apt-get update && \
+    apt-get -y install octave && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# install Julia
+RUN  curl -fsSL https://install.julialang.org | sh -s -- --yes
+
+# Clone the 42 repo for a specific branch
+RUN git clone --recurse-submodules -b ${GIT_BRANCH} -j2 ${GIT_URL}
+RUN cd ./42 && make -j2
+
+COPY entrypoint.sh /entrypoint.sh
+
+COPY startapp.sh /startapp.sh
+
+CMD ["/entrypoint.sh"]

--- a/containers/startapp.sh
+++ b/containers/startapp.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 export DISPLAY=:1
 
-cd ./42 && xterm -e ./42 &
+cd ./42 && make clean && make -j2 
+
+xterm -e ./42 &
 xterm &
 
 tail -f /dev/null


### PR DESCRIPTION
## Issue(s):

#165 : ensure that /startapp.sh compiles 42 in podman/docker

**_This ticket has no impact on 42's native code base_**. This implementation Closes #165 

## Overview:

Altered [startapp.sh](https://github.com/ericstoneking/42/compare/issue_165?expand=1#diff-c0b5c3fcbe7a982ac5bc82c96995f4ef2d523caa661dcdb3293355ecdbe57d51) to `make clean && make -j2` to ensure that 42 is compiled and ready for use or is already running

## Verify

run `make build up` then go to [http://localhost:5801/vnc.html]( http://localhost:5801/vnc.html) and confirm that 42 has already been compiled and is running or is runnable.

## Expected Results:

When 42 starts in [http://localhost:5801/vnc.html]( http://localhost:5801/vnc.html) the 42 is compiled and running.

## Dependencies:
N/A

## Optional
N/A

## Known issue(s)
N/A