### PR TITLE
Fixed off-by-one error in IPC code

### DIFF
--- a/MetaCode/JsonToAcIPC.jl
+++ b/MetaCode/JsonToAcIPC.jl
@@ -403,7 +403,7 @@ function BuildScBufLenWriteString()
       F *= "      int MsgLen = 0;\n";
       F *= "      int Success;\n";
       F *= "\n";
-      F *= "      Msg = (char *) calloc($N,sizeof(long));\n";
+      F *= "      Msg = (char *) calloc($N+1,sizeof(long));\n";
       F *= "\n";
       for i=1:N
          F *= "      NumBytes = sizeof(long);\n";

--- a/Source/AutoCode/ScIPC.c
+++ b/Source/AutoCode/ScIPC.c
@@ -1778,7 +1778,7 @@ void WriteAcBufLensToSocket(struct AcIpcType *I)
       int MsgLen = 0;
       int Success;
 
-      Msg = (char *) calloc(3,sizeof(long));
+      Msg = (char *) calloc(3+1,sizeof(long));
 
       NumBytes = sizeof(long);
       memcpy(&Msg[MsgLen],&I->AcInBufLen,NumBytes);


### PR DESCRIPTION
The message buffer is not allocating enough memory to hold the null terminator that is added later with `memset` - causing undefined behaviour.

Other functions in the IPC code (like `WriteAcArraySizesToSocket`) do it correctly. I assume someone just missed this one.
Without this change, the standalone example crashes and is unreliable due to corrupted memory.