### PR TITLE
Allow absolute paths for the models and InOut files

### DIFF
--- a/Source/42init.c
+++ b/Source/42init.c
@@ -4551,8 +4551,8 @@ void InitSim(int argc, char **argv)
       #else
          sprintf(InOutPath,"./InOut/");
          sprintf(ModelPath,"./Model/");
-         if (argc > 1) sprintf(InOutPath,"./%s/",argv[1]);
-         if (argc > 2) sprintf(ModelPath,"./%s/",argv[2]);
+         if (argc > 1) sprintf(InOutPath,"%s/",argv[1]);
+         if (argc > 2) sprintf(ModelPath,"%s/",argv[2]);
       #endif
 
 /* .. Read from file Inp_Sim.txt */


### PR DESCRIPTION
Is there a specific reason why the paths for the Model and InOut files must start with `./`? This is causing issues with absolute paths.

Otherwise, I propose to remove this restriction and also allow for absolute paths.