### PR TITLE
Fix CSS albedo quantization issue by using floating-point FBO

### DIFF
--- a/Source/42gpgpu.c
+++ b/Source/42gpgpu.c
@@ -21,6 +21,10 @@
 #include "glkit.h"
 #undef EXTERN
 
+#ifndef GL_RGBA32F
+#define GL_RGBA32F 0x8814
+#endif
+
 GLuint EarthAlbedoCubeTag;
 GLuint GenericAlbedoCubeTag;
 GLuint AlbedoWindow;
@@ -59,7 +63,7 @@ void InitAlbedo(void)
       /* Create Textures */
       glGenTextures(1,(GLuint *) &A->TexTag);
       glBindTexture(GL_TEXTURE_2D,A->TexTag);
-      glTexImage2D(GL_TEXTURE_2D,0,GL_RGBA,A->Width,A->Height,0,
+      glTexImage2D(GL_TEXTURE_2D,0,GL_RGBA32F,A->Width,A->Height,0,
          GL_RGBA,GL_FLOAT,NULL);
       glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_WRAP_S,GL_CLAMP);
       glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_WRAP_T,GL_CLAMP);
@@ -70,7 +74,7 @@ void InitAlbedo(void)
       glGenRenderbuffers(1,&A->RenderTag);
       glBindRenderbuffer(GL_RENDERBUFFER,A->RenderTag);
       glRenderbufferStorage(GL_RENDERBUFFER,
-         GL_RGBA,A->Width,A->Height);
+         GL_RGBA32F,A->Width,A->Height);
 
       glFramebufferTexture2D(GL_FRAMEBUFFER,GL_COLOR_ATTACHMENT0,GL_TEXTURE_2D,A->TexTag,0);
 


### PR DESCRIPTION
## Summary
This PR fixes the CSS albedo calculation issue where all values were incorrectly returning zero due to 8-bit quantization in the framebuffer object (FBO).

## Problem
The albedo calculation in `FindCssAlbedo()` produces very small values (order of 1e-5) after applying the physical scaling factor. When using the default `GL_RGBA` format (8-bit per channel), these values get quantized to zero since they're below the minimum representable value (1/255 ≈ 0.0039).

## Solution
Changed the FBO configuration in `InitAlbedo()` to use 32-bit floating-point formats:
- Texture format: `GL_RGBA` → `GL_RGBA32F`
- Renderbuffer format: `GL_RGBA` → `GL_RGBA32F`

Fixes Issue #178 .

## Changes Made
- Added `GL_RGBA32F` definition for compatibility
- Updated `glTexImage2D()` internal format parameter
- Updated `glRenderbufferStorage()` format parameter

## Testing
Tested with NOS3 simulation:

**Before (8-bit FBO):**
Albedo.42:
`0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00`

**After (32-bit float FBO):**
Albedo.42:
`3.436683e-02 1.222055e-01 1.621280e-01 8.477484e-03 1.545125e-01 1.246450e-02`

The values now correctly show Earth albedo contributions in the physically expected range.

## Verification
- Albedo values are now non-zero and physically reasonable
- CSS illumination values (`Illum.42`) properly include albedo contributions
- No saturation or overflow in sensor readings
- Maintains physical correctness with original ScaleFactor

## Files Changed
- `Source/42gpgpu.c`: Modified `InitAlbedo()` function

## Notes
The `GL_RGBA32F` constant (0x8814) is defined in OpenGL 3.0+ and the ARB_texture_float extension. The added `#ifndef` guard ensures compatibility with older GL headers.
